### PR TITLE
Avoid sharing edge properties between builder instances

### DIFF
--- a/or_datasets/linerlib.py
+++ b/or_datasets/linerlib.py
@@ -271,11 +271,11 @@ class GraphBuilder:
     """The forfeit edge cost."""
 
     # edge attributes
-    cost: List[float] = []
+    cost: List[float]
     """The edge costs."""
-    travelTime: List[float] = []
+    travelTime: List[float]
     """The edge transshipment times."""
-    capacity: List[int] = []
+    capacity: List[int]
     """The edge capacities."""
 
     def __init__(self, data, network):
@@ -293,6 +293,9 @@ class GraphBuilder:
         self.rotationName, self.rotations, self.speed, self.capacities = network[
             "instance"
         ]
+        self.cost = []
+        self.travelTime = []
+        self.capacity = []
 
     def portCallNodes(self) -> List[str]:
         """


### PR DESCRIPTION
Before this change, a single list would be created and shared between any instances of `GraphBuilder`. This quickly becomes error prone if you use more than one builder in the same context.

For example:

```python
data = linerlib.fetch_linerlib(instance="Baltic")
network = linerlib.fetch_linerlib_rotations(instance="Baltic_best_base")
builder1 = linerlib.GraphBuilder(data, network)
builder2 = linerlib.GraphBuilder(data, network)
print(len(builder1.cost))  # 0, as expected
print(len(builder2.cost))  # 0, as expected
builder1.transitEdges()
print(len(builder1.cost))  # 8, as expected
print(len(builder2.cost))  # 8, but expected 0 since transitEdges is only invoked on builder1
```