### PR TITLE
Correctly handle booleans in data

### DIFF
--- a/or_datasets/linerlib.py
+++ b/or_datasets/linerlib.py
@@ -59,7 +59,7 @@ def _convertToNumeric(key, value):
         return float(value)
 
     if value and key in booleanKeys:
-        return bool(value)
+        return value == '1'
 
     return value
 


### PR DESCRIPTION
Prior to this change, the parsed `IsPanama` and `IsSuez` would always be `True`, regardless of the value in the data, as the data would be parsed in the strings `'0'` or `'1'`, and `bool('0')` is `True`.